### PR TITLE
Renamed lngLat to latLng

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ exports.grabAddressInfo = async function (address, options) {
 		const district = await page.$eval('.address-list > li.row:nth-child(4) > .col > .text-warning', el => el.innerText);
 		const areaCode = await page.$eval('.address-list > li.row:nth-child(5) > .col > .text-warning', el => el.innerText);
 		const postCode = await page.$eval('.address-list > li.row:nth-child(6) > .col > .text-warning', el => el.innerText);
-		const lngLat = await page.$eval('.address-list > li.row:nth-child(7) > .col > .text-warning', el => el.innerText);
+		const latLng = await page.$eval('.address-list > li.row:nth-child(7) > .col > .text-warning', el => el.innerText);
 
 		const data = {
 			'DigitalAddress':address,
@@ -52,7 +52,7 @@ exports.grabAddressInfo = async function (address, options) {
 			"district": district,
 			"postCode": postCode,
 			"areaCode": areaCode,
-			"lngLat": lngLat
+			"latLng": latLng
 		};
 
 		await browser.close();
@@ -70,7 +70,7 @@ exports.grabAddressInfo = async function (address, options) {
 			"district": null,
 			"postCode": 'N/A',
 			"areaCode": "N/A",
-			"lngLat": 'N/A'
+			"latLng": 'N/A'
 		};
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,9 @@
 {
-  "name": "ghanapost",
-  "version": "1.0.0",
+  "name": "ghpost-address",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@derhuerst/location": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@derhuerst/location/-/location-1.0.0.tgz",
-      "integrity": "sha512-5r+Eo4N1ipUOg3Rh7LJ5UuV0mfyOHw/JSl+fOH09HQj7F0TIdOERfG3B5PsTdVo5/nQFfNJoT7rlWl1Do8hSDw==",
-      "requires": {
-        "wifi-triangulate": "^1.1.2"
-      }
-    },
     "agent-base": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
@@ -125,14 +117,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "geocode-wifi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/geocode-wifi/-/geocode-wifi-1.0.1.tgz",
-      "integrity": "sha1-Yt2EmtRwhoN7tQKwrhpKO4MzAfk=",
-      "requires": {
-        "once": "^1.3.2"
-      }
-    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -169,23 +153,10 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
     },
     "mime": {
       "version": "2.3.1",
@@ -218,28 +189,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
-    "node-wifiscanner2": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-wifiscanner2/-/node-wifiscanner2-1.2.0.tgz",
-      "integrity": "sha1-ln+tDXV7Qwo5snGNQIy72ewetIA=",
-      "requires": {
-        "os-locale": "^1.4.0"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
       }
     },
     "path-is-absolute": {
@@ -326,15 +281,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "wifi-triangulate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wifi-triangulate/-/wifi-triangulate-1.1.2.tgz",
-      "integrity": "sha1-/mtEL863C44jOzJBo3wxvMiKQ40=",
-      "requires": {
-        "geocode-wifi": "^1.0.1",
-        "node-wifiscanner2": "^1.2.0"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ This will give you something similar to the following:
   region: 'Ashanti',
   district: 'Kumasi',
   postCode: 'AK507',
-  lngLat: '6.669813,-1.561062' 
+  latLng: '6.669813,-1.561062' 
 }
 
 ```
@@ -42,7 +42,7 @@ This will give you something similar to the following:
 ```js
 { grabAddressInfo: [AsyncFunction] }
 
-grabAddressInfo(adrress, options)
+grabAddressInfo(address, options)
 
 
 address can be PostCode, coodinates, Digital Address, Places


### PR DESCRIPTION
This PR seeks to resolve issue #6 by renaming `lngLat` to `latLng` in the data returned.

> In the case of backward compatibility, the `lngLat` can still be added and removed completely in a later release.